### PR TITLE
Feature/pagination

### DIFF
--- a/src/reducers/api/basic/README.md
+++ b/src/reducers/api/basic/README.md
@@ -12,11 +12,12 @@ The whole config object and its properties is optional.
 
 -   `actionTypes: Object`
 
-    -   `REQUEST: String|Symbol (or any primitive type)` - recommended, not required
+    -   `REQUEST: String|Symbol (or any primitive type)` - recommended for basic usage
     -   `INVALIDATE: String|Symbol`
-    -   `SUCCESS: String|Symbol` - recommended, not required
-    -   `FAILURE: String|Symbol` - recommended, not required
+    -   `SUCCESS: String|Symbol` - recommended for basic usage
+    -   `FAILURE: String|Symbol` - recommended for basic usage
     -   `RESET: String|Symbol`
+    -   `UPDATE: String|Symbol`
 
 -   `initialState: Object`
 
@@ -26,7 +27,11 @@ The whole config object and its properties is optional.
     -   `didInvalidate: Boolean`
 
 -   `options: Object`
+
     -   `logging: Boolean`
+
+-   `actionFilters: Object`
+    -   `update: Function`
 
 ### Returns
 
@@ -52,6 +57,9 @@ The whole config object and its properties is optional.
 
         // reset reducer to initial state
         RESET: UNUSED_ACTION_TYPE,
+
+        // arbitrary state update (new state = current state merged with action.payload object)
+        UPDATE: UNUSED_ACTION_TYPE,
     },
 
     // reducer initial state
@@ -76,6 +84,12 @@ The whole config object and its properties is optional.
     },
     options: {
         logging: process.env.NODE_ENV === 'development'
+    },
+    actionFilter: {
+        // action UPDATE is passed here as 1st arg.
+        // The function returns boolean. If true is returned,
+        // state is merged with an action.payload object.
+        update: action => true,
     }
 }
 ```

--- a/src/reducers/api/basic/config.js
+++ b/src/reducers/api/basic/config.js
@@ -6,6 +6,7 @@ export const actionTypes = {
     SUCCESS: UNUSED_ACTION_TYPE,
     FAILURE: UNUSED_ACTION_TYPE,
     RESET: UNUSED_ACTION_TYPE,
+    UPDATE: UNUSED_ACTION_TYPE,
 };
 
 export const initialState = {
@@ -23,3 +24,7 @@ export const options = {
 };
 
 export const selectors = {};
+
+export const actionFilters = {
+    update: () => false,
+};

--- a/src/reducers/api/basic/factoryReducer.js
+++ b/src/reducers/api/basic/factoryReducer.js
@@ -22,12 +22,16 @@ const getParams = (customParams = {}) => {
             ...Config.actionTypes,
             ...customParams.actionTypes,
         },
+        actionFilters: {
+            ...Config.actionFilters,
+            ...customParams.actionFilters,
+        },
         options,
     };
 };
 
 export default function makeBasicApiReducer(customParams) {
-    const { actionTypes: types, initialState } = getParams(customParams);
+    const { actionTypes: types, initialState, actionFilters } = getParams(customParams);
 
     function basicApiReducer(state = initialState, action) {
         switch (action.type) {
@@ -67,12 +71,23 @@ export default function makeBasicApiReducer(customParams) {
             case types.RESET:
                 return initialState;
 
+            case types.UPDATE: {
+                if (actionFilters.update(action)) {
+                    return {
+                        ...state,
+                        ...action.payload,
+                    };
+                }
+
+                return state;
+            }
+
             default:
                 return state;
         }
     }
 
-    basicApiReducer.getInitialState = () => initialState;
+    basicApiReducer.INITIAL_STATE = initialState;
 
     return basicApiReducer;
 }

--- a/src/reducers/api/pagination/README.md
+++ b/src/reducers/api/pagination/README.md
@@ -19,11 +19,13 @@ This reducer can handle both of them.
 
 -   `actionTypes: Object`
 
-    -   `REQUEST: String|Symbol (or any primitive type)` - recommended, not required
+    -   `REQUEST: String|Symbol (or any primitive type)` - recommended for basic usage
     -   `INVALIDATE: String|Symbol`
-    -   `SUCCESS: String|Symbol` - recommended, not required
-    -   `FAILURE: String|Symbol` - recommended, not required
+    -   `SUCCESS: String|Symbol` - recommended for basic usage
+    -   `FAILURE: String|Symbol` - recommended for basic usage
     -   `RESET: String|Symbol`
+    -   `SET_PAGE: String|Symbol`
+    -   `UPDATE: String|Symbol`
 
 -   `initialState: Object`
 
@@ -43,7 +45,12 @@ This reducer can handle both of them.
     -   `currentCount: Function` - required
 
 -   `options: Object`
+
     -   `logging: Boolean`
+
+-   `actionFilters: Object`
+    -   `setPage: Function`
+    -   `update: Function`
 
 ### Returns
 
@@ -69,6 +76,12 @@ This reducer can handle both of them.
 
         // reset reducer to initial state
         RESET: UNUSED_ACTION_TYPE,
+
+        // action that updates 'page' property (action.payload.page)
+        SET_PAGE: UNUSED_ACTION_TYPE,
+
+        // arbitrary state update (new state = current state merged with action.payload object)
+        UPDATE: UNUSED_ACTION_TYPE,
     },
 
     // reducer initial state
@@ -111,7 +124,16 @@ This reducer can handle both of them.
         currentCount: action => action.payload.ids.length,
     },
     options: {
-        logging: process.env.NODE_ENV === 'development'
+        logging: process.env.NODE_ENV === 'development',
+    },
+    actionFilters: {
+        // To be able to use general action, here is action validator where you can filter out unwanted actions (e.g. action.meta.category !== 'myCategory')
+        setPage: action => true,
+
+        // action UPDATE is passed here as 1st arg.
+        // The function returns boolean. If true is returned,
+        // state is merged with an action.payload object.
+        update: action => true,
     }
 }
 ```

--- a/src/reducers/api/pagination/config.js
+++ b/src/reducers/api/pagination/config.js
@@ -1,7 +1,10 @@
-import { isEnvDevelopment } from '../../../constants';
+import { isEnvDevelopment, UNUSED_ACTION_TYPE } from '../../../constants';
 import * as BasicAPIReducer from '../basic';
 
-export const { actionTypes } = BasicAPIReducer.config;
+export const actionTypes = {
+    ...BasicAPIReducer.config,
+    SET_PAGE: UNUSED_ACTION_TYPE,
+};
 
 export const initialState = {
     ...BasicAPIReducer.config.initialState,
@@ -28,4 +31,8 @@ export const options = {
 export const selectors = {
     totalCount: action => action.meta.totalCount,
     currentCount: action => action.payload.ids.length,
+};
+
+export const actionFilters = {
+    setPage: () => false,
 };

--- a/src/reducers/api/pagination/factoryReducer.js
+++ b/src/reducers/api/pagination/factoryReducer.js
@@ -28,12 +28,16 @@ const getParams = (customParams = {}) => {
             ...Config.selectors,
             ...customParams.selectors,
         },
+        actionFilters: {
+            ...Config.actionFilters,
+            ...customParams.actionFilters,
+        },
         options,
     };
 };
 
 export default function makePaginationApiReducer(customParams) {
-    const { actionTypes: types, initialState, selectors, options } = getParams(customParams);
+    const { actionTypes: types, initialState, selectors, options, actionFilters } = getParams(customParams);
 
     const basicApiReducer = makeBasicApiReducer({
         actionTypes: types,
@@ -64,6 +68,19 @@ export default function makePaginationApiReducer(customParams) {
                     hasMore,
                     totalCount,
                 };
+            }
+
+            case types.SET_PAGE: {
+                if (actionFilters.setPage(action)) {
+                    const { page } = action.payload;
+
+                    return {
+                        ...state,
+                        page,
+                    };
+                }
+
+                return state;
             }
 
             default:

--- a/src/reducers/api/pagination/factoryReducer.js
+++ b/src/reducers/api/pagination/factoryReducer.js
@@ -51,6 +51,7 @@ export default function makePaginationApiReducer(customParams) {
             case types.INVALIDATE:
             case types.FAILURE:
             case types.RESET:
+            case types.UPDATE:
                 return {
                     ...state,
                     ...basicApiReducer(state, action),


### PR DESCRIPTION
extend API reducer factories available configurations by the following params:
`basic`:
- `actionTypes` has now `UPDATE` action type which can update whole reducer state (the new state is equal to a merged value of current state and an `action.payload` object)
-  `actionFilters` includes validator for the `UPDATE` action type called `update`. Each action filter returns boolean if true is returned then the action is applied and state is updated. 

`pagination` 
- except for the changes above, the pagination reducer includes `SET_PAGE` action type with `setPage` action filter 