### PR TITLE
Don't increase page on SUCCESS, this must be handled externally

### DIFF
--- a/src/reducers/api/pagination/factoryReducer.js
+++ b/src/reducers/api/pagination/factoryReducer.js
@@ -65,7 +65,6 @@ export default function makePaginationApiReducer(customParams) {
                 return {
                     ...state,
                     ...basicApiReducer(state, action),
-                    page: hasMore ? state.page + 1 : state.page,
                     hasMore,
                     totalCount,
                 };


### PR DESCRIPTION
Since `page` attribute is used to reflects UI pagination state, it mustn't be internally incremented on `SUCCESS` action.
The `page` attribute is changed externally with `SET_PAGE` action.