### PR TITLE
:wrench: Generate TS types to 'lib' output dir instead of 'es'

### DIFF
--- a/tsconfig.types.json
+++ b/tsconfig.types.json
@@ -1,27 +1,23 @@
 {
     "compilerOptions": {
-        "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
-        "module": "esnext",                       /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
-        "lib": [
-            "dom",
-            "dom.iterable",
-            "esnext"
-        ],
-        "allowJs": true,                          /* Do not emit comments to output. */
-        "isolatedModules": true,                  /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+        "target": "es5" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
+        "module": "esnext" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
+        "lib": ["dom", "dom.iterable", "esnext"],
+        "allowJs": true /* Do not emit comments to output. */,
+        "isolatedModules": true /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */,
         "downlevelIteration": true,
-        "strict": false,                          /* Enable all strict type-checking options. */
-        "noUnusedLocals": true,                   /* Report errors on unused locals. */
-        "moduleResolution": "node",               /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+        "strict": false /* Enable all strict type-checking options. */,
+        "noUnusedLocals": true /* Report errors on unused locals. */,
+        "moduleResolution": "node" /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */,
         // Generate corresponding .d.ts file.
         "declaration": true,
         "resolveJsonModule": true,
-        "allowSyntheticDefaultImports": true,     /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-        "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
-        "skipLibCheck": true,                     /* Skip type checking of declaration files. */
-        "forceConsistentCasingInFileNames": true, /* Disallow inconsistently-cased references to the same file. */
+        "allowSyntheticDefaultImports": true /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */,
+        "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
+        "skipLibCheck": true /* Skip type checking of declaration files. */,
+        "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */,
         "jsx": "react",
-        "outDir": "es"
+        "outDir": "lib"
     },
     "include": ["src"],
     "exclude": ["**/__tests__/"]


### PR DESCRIPTION
If use use the package:
```js
import { ... } from '@ackee/redux-utils';
```
it's gonna import modules from `lib` dir. And if there're no types, there'll be no type completion.