### PR TITLE
:sparkles: Add createApiActions utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Common Redux utilities, including:
         -   [`apiRequestType`](./docs/utils/apiRequestType.md#apiRequestType)
         -   [`createApiRequestType`](./docs/utils/apiRequestType.md#createApiRequestType)
     -   Action Creator helpers
+        -   [`createApiActions`]('./docs/actions/apiActions.md)
         -   [`apiRequestActions`](./docs/actions/request.md)
         -   [`createApiRequestActions`](./docs/actions/createApiRequest.md)
     -   Reducer factories

--- a/docs/actions/apiActions.md
+++ b/docs/actions/apiActions.md
@@ -1,4 +1,4 @@
-# `createApiRequestActions`
+# `createApiActions`
 
 Creates action creators and types to reflect an API request with `createAction` utility from `@reduxjs/toolkit`.
 
@@ -13,7 +13,7 @@ const fetchUsers = createApiActions<'FETCH_USERS', RequestPayload>('FETCH_USERS'
 // a)
 dispatch(fetchUser.request({ page: 1, limit: 10 }));
 
-// b) The `action` will be type of `fetchUsers.request`:
+// b) The `action` will be type of `fetchUser.request`:
 createReducer(fetchUser.request, (state, action) => {
     // ...
 });

--- a/docs/actions/apiActions.md
+++ b/docs/actions/apiActions.md
@@ -1,0 +1,27 @@
+# `createApiRequestActions`
+
+Creates action creators and types to reflect an API request with `createAction` utility from `@reduxjs/toolkit`.
+
+```ts
+type RequestPayload = {
+    page: number;
+    limit: number;
+};
+
+const fetchUsers = createApiActions<'FETCH_USERS', RequestPayload>('FETCH_USERS');
+
+// a)
+dispatch(fetchUser.request({ page: 1, limit: 10 }));
+
+// b) The `action` will be type of `fetchUsers.request`:
+createReducer(fetchUser.request, (state, action) => {
+    // ...
+});
+
+// c) Pass `types` directly to an api reducer without additional mapping:
+basicApiReducer({
+    actionTypes: fetchUsers.types,
+});
+```
+
+See [implementation](../../src/actions/apiActions.ts) for more details.

--- a/src/actions/apiActions.ts
+++ b/src/actions/apiActions.ts
@@ -1,0 +1,53 @@
+import { createAction } from '@reduxjs/toolkit';
+
+/**
+ * Creates action creators and types to reflect an API request with `createAction` utility from `@reduxjs/toolkit`.
+ * @example
+    type RequestPayload = {
+        page: number;
+        limit: number;
+    };
+
+    const fetchUsers = createApiActions<'FETCH_USERS', RequestPayload>('FETCH_USERS');
+    
+    // a) 
+    dispatch(fetchUser.request({ page: 1, limit: 10 }))
+
+    // b) The `action` will be type of `fetchUsers.request`:
+    createReducer(fetchUser.request, (state, action) => {
+        // ...
+    })
+
+    // c) Pass `types` directly to an api reducer without additional mapping:
+    basicApiReducer({
+        actionTypes: fetchUsers.types,
+    })
+ */
+export function createApiActions<
+    TP extends string,
+    RequestPayload = any,
+    SuccessPayload = any,
+    FailurePayload = { error: string },
+    ResetPayload = void,
+    CancelPayload = void,
+>(typePrefix: TP) {
+    const types = {
+        REQUEST: `${typePrefix}_REQUEST`,
+        SUCCESS: `${typePrefix}_SUCCESS`,
+        FAILURE: `${typePrefix}_FAILURE`,
+        RESET: `${typePrefix}_RESET`,
+        CANCEL: `${typePrefix}_CANCEL`,
+    } as const;
+
+    type Types = typeof types;
+
+    return {
+        types,
+
+        request: createAction<RequestPayload, Types['REQUEST']>(types.REQUEST),
+        success: createAction<SuccessPayload, Types['SUCCESS']>(types.SUCCESS),
+        failure: createAction<FailurePayload, Types['FAILURE']>(types.FAILURE),
+        reset: createAction<ResetPayload, Types['RESET']>(types.RESET),
+        cancel: createAction<CancelPayload, Types['CANCEL']>(types.CANCEL),
+    } as const;
+}

--- a/src/actions/apiRequest/createApiRequestActions.ts
+++ b/src/actions/apiRequest/createApiRequestActions.ts
@@ -8,6 +8,9 @@ export interface ApiActionTypes {
     RESET?: string;
 }
 
+/**
+ * @deprecated - `createApiActions` util
+ */
 export const createApiRequestActions = <RP = any, SP = any, SM = any | undefined, E = Error | string | object>(
     types: ApiActionTypes,
 ) => ({
@@ -26,6 +29,9 @@ export const createApiRequestActions = <RP = any, SP = any, SM = any | undefined
     reset: types.RESET ? createAction(types.RESET) : undefined,
 });
 
+/**
+ * @deprecated - `createApiActions` util
+ */
 export const createApiDetailRequestActions = <
     Id = string | number,
     RP = any,

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,3 +17,5 @@ export { default as paginationApiReducer } from './reducers/api/pagination/facto
 export { default as containerReducer } from './reducers/container/factoryReducer';
 
 export { default as basicResetReducer } from './reducers/reset/basic/factoryReducer';
+
+export * from './actions/apiActions';


### PR DESCRIPTION
Why? Because current solutions are over-designed and can't be used directly with api reducers.

I think the code example speaks for itself better than words, so:
```ts
type RequestPayload = {
    page: number;
    limit: number;
};

const fetchUsers = createApiActions<'FETCH_USERS', RequestPayload>('FETCH_USERS');

// a)
dispatch(fetchUser.request({ page: 1, limit: 10 }));

// b) The `action` will be type of `fetchUsers.request`:
createReducer(fetchUser.request, (state, action) => {
    // ...
});

// c) Pass `types` directly to an api reducer without additional mapping:
basicApiReducer({
    actionTypes: fetchUsers.types,
});
```